### PR TITLE
No white space in workflow name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Create Release
+name: Release
 
 on:
   push:


### PR DESCRIPTION
good practice to keep links to URL ( logs, badges ... ) clean
